### PR TITLE
Use Guzzle setPostField to avoid breaking when @ in password.

### DIFF
--- a/src/Authentication/PasswordAuthentication.php
+++ b/src/Authentication/PasswordAuthentication.php
@@ -63,7 +63,10 @@ class PasswordAuthentication implements AuthenticationInterface, LoggerAwareInte
             'username' => $this->username,
             'password' => $this->password . $this->securityToken,
         );
-        $request = $this->guzzle->post('oauth2/token', null, $postFields);
+        $request = $this->guzzle->post('oauth2/token', null);
+        foreach ($postFields as $key => $value) {
+          $request = $request->setPostField($key, $value);
+        }
         $request->setAuth('user', 'pass');
         $response = $request->send();
         $responseBody = $response->getBody();


### PR DESCRIPTION
Hello,

Thanks for the great library!

I happened to be working with an account where there was an @ symbol in the password. This is a special symbol for Guzzle indicating a file path, so it caused a fatal error when it couldn't open a file that didn't exist (the "file" being the part of the password after the @).

I fixed it as described here: https://stackoverflow.com/a/33635091/4892731.

A pull request is attached in case you're interested in incorporating the change.

Thanks!